### PR TITLE
Execute jobs once when they are scheduled before the cron spec (jitter)

### DIFF
--- a/jitter.go
+++ b/jitter.go
@@ -9,6 +9,7 @@ type Jitter interface {
 	// generates and returns a random duration in the set [-j.Deviation, j.Deviation)
 	Generate() time.Duration
 	WithSource(rand.Source) Jitter
+	Max() time.Duration
 }
 
 func WrapWithJitter(schedule Schedule, jitter Jitter) Schedule {
@@ -26,8 +27,13 @@ type ScheduleWithJitter struct {
 func (s *ScheduleWithJitter) Next(t time.Time) time.Time {
 	// when's next?
 	ts := s.schedule.Next(t)
-	// factor jitter in
-	if s.jitter != nil {
+	// factor jitter in? (only in cases where it is necessary)
+	if s.jitter != nil && s.jitter.Max() > 0 {
+		// we don't want a job to run twice within the same jitter window
+		// this happens in cases of negative jitter
+		if ts.Sub(t) < s.jitter.Max() {
+			ts = s.schedule.Next(t.Add(s.jitter.Max()))
+		}
 		if pt := ts.Add(s.jitter.Generate()); pt.After(t) {
 			ts = pt
 		}
@@ -45,6 +51,10 @@ func (j UniformJitter) WithSource(src rand.Source) Jitter {
 
 func (j UniformJitter) adjust(n int64) time.Duration {
 	return time.Duration(n%(2*int64(j.Deviation)) - int64(j.Deviation))
+}
+
+func (j UniformJitter) Max() time.Duration {
+	return j.Deviation
 }
 
 // generates and returns a random duration in the set [-j.Deviation, j.Deviation)

--- a/option.go
+++ b/option.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"math/rand"
 	"time"
 )
 
@@ -41,5 +42,13 @@ func WithChain(wrappers ...JobWrapper) Option {
 func WithLogger(logger Logger) Option {
 	return func(c *Cron) {
 		c.logger = logger
+	}
+}
+
+// WithSeed seeds the random number generator with the supplied number
+// for use with jitter functionality
+func WithSeed(seed int64) Option {
+	return func(_ *Cron) {
+		rand.Seed(seed)
 	}
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -211,7 +211,9 @@ func TestNextWithJitter(t *testing.T) {
 		// expect in 15 mins, 1m jitter
 		{"Mon Jul 9 14:45 2012", "0 0/15 * * * *", UniformJitter{time.Minute}, "Mon Jul 9 15:00 2012"},
 		// expect in 15 mins, 20m jitter
-		{"Mon Jul 9 14:45 2012", "0 0/15 * * * *", UniformJitter{20 * time.Minute}, "Mon Jul 9 15:00 2012"},
+		{"Mon Jul 9 14:45 2012", "0 0/15 * * * *", UniformJitter{20 * time.Minute}, "Mon Jul 9 15:15 2012"},
+		// expect in 5 mins, 15m jitter
+		{"Mon Jul 9 14:55 2012", "0 0/5 * * * *", UniformJitter{15 * time.Minute}, "Mon Jul 9 15:15 2012"},
 		// expect in 35 mins, 5m jitter
 		{"Mon Jul 9 15:45 2012", "0 20-35/15 * * * *", UniformJitter{5 * time.Minute}, "Mon Jul 9 16:20 2012"},
 


### PR DESCRIPTION
- Fix a bug that was causing multiple job executions when the
  `JITTER=` prefix is used in a cron spec and the job is eventually
  scheduled to run before the time specified with the usual cron format.
- Add tests